### PR TITLE
feat: add Appium troubleshooting skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ This file defines how AI agents should execute the skills in this repository.
 ### Troubleshooting
 
 1. If prerequisites or doctor checks are failing, run the relevant environment setup skill first.
-2. Then run `appium-troubleshooting` and load only the platform reference files that match the symptom.
+2. Then run `appium-troubleshooting` in the failing driver path and load only the platform reference files that match the symptom.
 
 ## Completion Policy
 
@@ -170,6 +170,7 @@ Follow this order:
 
 Rules:
 - Run one step at a time.
+- Keep troubleshooting scoped to the failing driver unless the user explicitly asks for cross-driver comparison.
 - Re-run the smallest failing check after each fix.
 - Treat Appium doctor required fixes as blocking.
 - Prefer the official Appium references bundled with the troubleshooting skill before using discuss.appium.io.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ This file defines how AI agents should execute the skills in this repository.
 1. `environment-setup-node`
 2. `environment-setup-xcuitest`
 
+### Troubleshooting
+
+1. If prerequisites or doctor checks are failing, run the relevant environment setup skill first.
+2. Then run `appium-troubleshooting` and load only the platform reference files that match the symptom.
+
 ## Completion Policy
 
 A skill is complete only when its own completion criteria in `SKILL.md` are satisfied.
@@ -119,6 +124,25 @@ Rules:
   2) In Terminal B run `curl -s http://127.0.0.1:4723/status` and confirm success.
   3) In Terminal A logs confirm `Available drivers:` contains `xcuitest`.
   4) In Terminal A stop Appium with `Ctrl+C`, then in Terminal B run `pgrep -fl "appium.*server" || echo "no appium server process"`.
+```
+
+### Template: Troubleshooting
+
+Use this as a starting prompt for an AI agent:
+
+```text
+Use this repository's troubleshooting skill to diagnose an Appium failure.
+Follow this order:
+1) If setup or doctor output is failing, run the matching environment setup skill first.
+2) skills/appium-troubleshooting/SKILL.md
+
+Rules:
+- Run one step at a time.
+- Re-run the smallest failing check after each fix.
+- Treat Appium doctor required fixes as blocking.
+- Prefer the official Appium references bundled with the troubleshooting skill before using discuss.appium.io.
+- Use discuss.appium.io only when the official references do not explain the exact stack trace or symptom.
+- Show command output for each step.
 ```
 
 ## Notes for Tooling Integrations

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NOTE: This repository is currently in development.
 | [environment-setup-uiautomator2](skills/environment-setup-uiautomator2/SKILL.md) | Prepares and validates an Android + UiAutomator2 Appium environment |
 | [environment-setup-espresso](skills/environment-setup-espresso/SKILL.md) | Prepares and validates an Android + Espresso Appium environment |
 | [environment-setup-xcuitest](skills/environment-setup-xcuitest/SKILL.md) | Prepares and validates a macOS + XCUITest Appium environment |
-| [appium-troubleshooting](skills/appium-troubleshooting/SKILL.md) | Troubleshoots common UiAutomator2 and XCUITest startup, WebDriverAgent, and element lookup failures |
+| [appium-troubleshooting](skills/appium-troubleshooting/SKILL.md) | Troubleshoots UiAutomator2 or XCUITest failures with driver-scoped flows and required validation checks (`appium -v`, installed drivers, doctor output, and minimal repro re-run evidence) |
 
 ## Reliable Execution Notes
 
@@ -26,6 +26,7 @@ NOTE: This repository is currently in development.
 - For FFmpeg-dependent capabilities, run the optional shared skill `environment-setup-ffmpeg` only when explicitly requested.
 - For bundletool-dependent capabilities, run the optional shared skill `environment-setup-bundletool` only when explicitly requested.
 - For startup, WDA, or locator failures after setup is complete, use `appium-troubleshooting` and load only the relevant platform reference files.
+- For `appium-troubleshooting`, capture and report command evidence for `appium -v`, `appium driver list --installed`, selected-driver doctor output, and one minimal failing check re-run after each fix.
 
 ## Agent Instructions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Appium Agent Skills
 
-This repository contains AI Agent skills for preparing Appium driver environments.
+This repository contains AI Agent skills for preparing Appium driver environments and troubleshooting common driver failures.
 
 NOTE: This repository is currently in development.
 
@@ -15,6 +15,7 @@ NOTE: This repository is currently in development.
 | [environment-setup-uiautomator2](skills/environment-setup-uiautomator2/SKILL.md) | Prepares and validates an Android + UiAutomator2 Appium environment |
 | [environment-setup-espresso](skills/environment-setup-espresso/SKILL.md) | Prepares and validates an Android + Espresso Appium environment |
 | [environment-setup-xcuitest](skills/environment-setup-xcuitest/SKILL.md) | Prepares and validates a macOS + XCUITest Appium environment |
+| [appium-troubleshooting](skills/appium-troubleshooting/SKILL.md) | Troubleshoots common UiAutomator2 and XCUITest startup, WebDriverAgent, and element lookup failures |
 
 ## Reliable Execution Notes
 
@@ -24,8 +25,9 @@ NOTE: This repository is currently in development.
 - Treat Appium doctor as the source of truth for pass/fail (`0 required fixes needed`).
 - For FFmpeg-dependent capabilities, run the optional shared skill `environment-setup-ffmpeg` only when explicitly requested.
 - For bundletool-dependent capabilities, run the optional shared skill `environment-setup-bundletool` only when explicitly requested.
+- For startup, WDA, or locator failures after setup is complete, use `appium-troubleshooting` and load only the relevant platform reference files.
 
 ## Agent Instructions
 
 - See [AGENTS.md](AGENTS.md) for strict execution rules and copy-paste prompt templates.
-- Use the template matching your target (`uiautomator2`, `espresso`, or `xcuitest`) and run skills in the documented order.
+- Use the template matching your target (`uiautomator2`, `espresso`, `xcuitest`, or `troubleshooting`) and run skills in the documented order.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains AI Agent skills for helping with Appium automation, inc
 | [environment-setup-uiautomator2](skills/environment-setup-uiautomator2/SKILL.md) | Prepares and validates an Android + UiAutomator2 Appium environment |
 | [environment-setup-espresso](skills/environment-setup-espresso/SKILL.md) | Prepares and validates an Android + Espresso Appium environment |
 | [environment-setup-xcuitest](skills/environment-setup-xcuitest/SKILL.md) | Prepares and validates a macOS + XCUITest Appium environment |
-| [appium-troubleshooting](skills/appium-troubleshooting/SKILL.md) | Troubleshoots UiAutomator2 or XCUITest failures with driver-scoped flows and required validation checks (`appium -v`, installed drivers, doctor output, and minimal repro re-run evidence) |
+| [appium-troubleshooting](skills/appium-troubleshooting/SKILL.md) | Troubleshoots UiAutomator2 or XCUITest failures with a driver-scoped workflow that starts from the failing symptom and re-checks the smallest reproduction after each fix |
 | [xcuitest-real-device-config](skills/xcuitest-real-device-config/SKILL.md) | Prepare a real iOS/tvOS device for Appium XCUITest automation |
 
 ## Reliable Execution Notes
@@ -24,8 +24,7 @@ This repository contains AI Agent skills for helping with Appium automation, inc
 - Treat Appium doctor as the source of truth for pass/fail (`0 required fixes needed`).
 - For FFmpeg-dependent capabilities, run the optional shared skill `environment-setup-ffmpeg` only when explicitly requested.
 - For bundletool-dependent capabilities, run the optional shared skill `environment-setup-bundletool` only when explicitly requested.
-- For startup, WDA, or locator failures after setup is complete, use `appium-troubleshooting` and load only the relevant platform reference files.
-- For `appium-troubleshooting`, capture and report command evidence for `appium -v`, `appium driver list --installed`, selected-driver doctor output, and one minimal failing check re-run after each fix.
+- For startup, WDA, or locator failures after setup is complete, use `appium-troubleshooting` in a single driver path and follow the checks documented in that skill.
 
 ## Agent Instructions
 

--- a/skills/appium-troubleshooting/SKILL.md
+++ b/skills/appium-troubleshooting/SKILL.md
@@ -2,7 +2,7 @@
 name: "appium-troubleshooting"
 description: "Diagnose common Appium failures with a driver-scoped flow for UiAutomator2 or XCUITest, covering startup, driver readiness, WebDriverAgent, and element lookup issues"
 metadata:
-  last_modified: "Tue, 17 Mar 2026 11:40:00 GMT"
+  last_modified: "Thu, 19 Mar 2026 12:00:00 GMT"
 
 ---
 # appium-troubleshooting
@@ -22,41 +22,32 @@ Help the agent narrow a single-driver Appium failure into a small set of common 
 - If the official docs do not explain the exact stack trace or symptom, use [references/community-search.md](references/community-search.md) as a fallback workflow.
 
 ## Instructions
-1. **Capture the exact failing surface and driver scope first**
-   Record the failing command, exact error text, platform, automation driver, and capabilities in play.
-   Minimum commands:
+1. **Capture the failing command and lock the driver scope**
+   Record the exact error text, platform, automation driver, and relevant capabilities before changing anything. If the driver is still unclear after checking the logs or capabilities, stop and ask.
+
+2. **Run the minimum baseline checks for that driver**
+   Always collect:
    ```bash
    appium -v
    appium driver list --installed
    ```
-   UiAutomator2-only checks:
+   UiAutomator2-only:
    ```bash
    adb devices -l
    appium driver doctor uiautomator2
    ```
-   XCUITest-only checks:
+   XCUITest-only:
    ```bash
    xcodebuild -version
    appium driver doctor xcuitest
    ```
+   If the selected-driver doctor or prerequisite check fails, switch to the matching setup skill before deeper troubleshooting.
 
-2. **Classify the failure in the selected driver path before changing anything**
-   Choose one primary bucket for that driver:
-   - prerequisite or doctor failure
-   - session startup or app launch failure
-   - device or simulator connectivity/state issue
-   - element lookup or locator issue
-   - unknown, but reproducible from logs
+3. **Open only the references that match the selected driver and symptom**
+   Do not load both driver branches in one run. Start with the most direct reference for the observed symptom and only expand if that file does not explain the behavior.
 
-3. **Open only driver-specific references**
-   Do not load both driver branches in one run. Start with the matching bucket in the selected driver path and expand only if the first file does not explain the behavior.
-
-4. **Apply one targeted fix at a time**
-   Prefer capability corrections, driver cleanup, device reset, or locator changes before broader environment churn.
-   After each fix, re-run the smallest failing check first:
-   - doctor command for prerequisite issues
-   - the single failing session launch for startup issues
-   - the single failing locator or inspector lookup for element issues
+4. **Apply one targeted change, then re-run the smallest failing check**
+   Prefer narrow fixes such as capability corrections, driver cleanup, device reset, or locator updates before broader environment churn. Re-run the doctor command for prerequisite issues, the failing session launch for startup issues, or the failing locator lookup for element issues.
 
 5. **Use official docs first, community second**
    Official references for this skill:
@@ -66,19 +57,8 @@ Help the agent narrow a single-driver Appium failure into a small set of common 
    - `https://github.com/appium/appium-xcuitest-driver`
    Use `discuss.appium.io` only after the official references are exhausted, searching with exact error text plus driver name and platform version.
 
-6. **Record checks/tests performed in the troubleshooting result**
-   Include command evidence for:
-   - `appium -v`
-   - `appium driver list --installed`
-   - selected-driver doctor output (`appium driver doctor uiautomator2` or `appium driver doctor xcuitest`)
-   - one minimal failing reproduction re-run after the fix
-   - platform check tied to selected driver (`adb devices -l` for UiAutomator2, `xcodebuild -version` for XCUITest)
-
-7. **Keep the result evidence-based**
-   End with:
-   - the confirmed or most likely root cause
-   - the change that was made
-   - the command or reproduction that now passes, or the exact blocker that still needs user action
+6. **Report the outcome with command evidence**
+   Include the baseline checks you ran, the change you made, and the smallest reproduction or check you re-ran to confirm the result.
 
 ## Completion Criteria
 Mark troubleshooting complete only when one of these is true:

--- a/skills/appium-troubleshooting/SKILL.md
+++ b/skills/appium-troubleshooting/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: "appium-troubleshooting"
+description: "Diagnose common Appium UiAutomator2 and XCUITest failures, including session startup, driver readiness, WebDriverAgent issues, and element lookup or locator problems"
+metadata:
+  last_modified: "Sat, 14 Mar 2026 17:21:12 GMT"
+
+---
+# appium-troubleshooting
+
+## Goal
+Help the agent narrow Appium failures into a small set of common buckets, apply the smallest plausible fix, and re-run the failing check until the root cause is confirmed or clearly handed back to the user.
+
+## Decision Logic
+- If the failure is really an environment or driver-install problem (`node`, `npm`, `appium`, Java, Android SDK, Xcode, doctor failures): run the relevant setup skill first.
+- If Android fails before the app settles, the wrong activity is detected, the session drops early, or `socket hang up` appears: read [references/uiautomator2-session-startup.md](references/uiautomator2-session-startup.md).
+- If Android locators are slow, flaky, or incorrect: read [references/uiautomator2-locators.md](references/uiautomator2-locators.md).
+- If iOS fails around WebDriverAgent startup, app install, system alerts, device communication, or simulator state: read [references/xcuitest-troubleshooting.md](references/xcuitest-troubleshooting.md).
+- If iOS elements cannot be found, the tree looks incomplete, or lookup performance is poor: read [references/xcuitest-element-lookup.md](references/xcuitest-element-lookup.md) and [references/xcuitest-locators.md](references/xcuitest-locators.md).
+- If the official docs do not explain the exact stack trace or symptom, use [references/community-search.md](references/community-search.md) as a fallback search workflow.
+
+## Instructions
+1. **Capture the exact failing surface first**
+   Record the failing command, the exact error text, the platform, the automation driver, and the capabilities in play.
+   Minimum commands:
+   ```bash
+   appium -v
+   appium driver list --installed
+   ```
+   Android:
+   ```bash
+   adb devices -l
+   appium driver doctor uiautomator2
+   ```
+   iOS:
+   ```bash
+   xcodebuild -version
+   appium driver doctor xcuitest
+   ```
+
+2. **Classify the failure before changing anything**
+   Choose one primary bucket:
+   - prerequisite or doctor failure
+   - session startup or app launch failure
+   - device or simulator connectivity/state issue
+   - element lookup or locator issue
+   - unknown, but reproducible from logs
+
+3. **Open only the relevant reference file**
+   Do not load every reference file by default. Start with the bucket that best matches the symptom, then expand only if the first path does not explain the behavior.
+
+4. **Apply one targeted fix at a time**
+   Prefer capability corrections, driver cleanup, device reset, or locator changes before broader environment churn.
+   After each fix, re-run the smallest failing check first:
+   - doctor command for prerequisite issues
+   - the single failing session launch for startup issues
+   - the single failing locator or inspector lookup for element issues
+
+5. **Use official docs first, community second**
+   The references in this skill summarize the official UiAutomator2 and XCUITest docs collected for `https://github.com/appium/skills/issues/9`.
+   Use `discuss.appium.io` only after the official references are exhausted, and search by exact error text plus driver name and platform version.
+
+6. **Keep the result evidence-based**
+   End with:
+   - the confirmed or most likely root cause
+   - the change that was made
+   - the command or reproduction that now passes, or the exact blocker that still needs user action
+
+## Completion Criteria
+Mark troubleshooting complete only when one of these is true:
+- the failing check passes after a verified fix, or
+- the exact blocker is isolated to something the user must do manually (for example signing, device trust, app build defects), with the relevant command output and next action captured
+
+## Constraints
+- Run commands one step at a time and re-run checks after each fix.
+- Treat Appium doctor required fixes as blocking.
+- Use global `appium` command mode by default unless the user explicitly asks for local `npx appium`.
+- Prefer the official Appium driver docs referenced by this skill before using community answers.
+- Do not claim success from a theory alone; always tie the conclusion to a reproduced symptom or a passing re-check.

--- a/skills/appium-troubleshooting/SKILL.md
+++ b/skills/appium-troubleshooting/SKILL.md
@@ -23,25 +23,17 @@ Help the agent narrow a single-driver Appium failure into a small set of common 
 
 ## Instructions
 1. **Capture the failing command and lock the driver scope**
-   Record the exact error text, platform, automation driver, and relevant capabilities before changing anything. If the driver is still unclear after checking the logs or capabilities, stop and ask.
+   Record the exact error text, platform, automation driver, and relevant capabilities before changing anything. If the driver is still unclear, ask for one of these before continuing:
+   - the desired capabilities block containing `platformName` and `appium:automationName`
+   - the Appium server log lines from `POST /session` through the first real error after `createSession`
+   If the client hides capabilities, rerun one failing session with Appium server logs enabled and capture that window before troubleshooting further.
 
-2. **Run the minimum baseline checks for that driver**
-   Always collect:
-   ```bash
-   appium -v
-   appium driver list --installed
-   ```
-   UiAutomator2-only:
-   ```bash
-   adb devices -l
-   appium driver doctor uiautomator2
-   ```
-   XCUITest-only:
-   ```bash
-   xcodebuild -version
-   appium driver doctor xcuitest
-   ```
-   If the selected-driver doctor or prerequisite check fails, switch to the matching setup skill before deeper troubleshooting.
+2. **Run baseline checks only when the error message alone is not enough**
+   If the error text already points to a known issue, open the matching driver-specific official reference first and confirm the closest symptom before changing anything. Then collect what is needed:
+   - `appium -v` and `appium driver list --installed` — to confirm driver presence and version.
+   - UiAutomator2: `adb devices -l` and `appium driver doctor uiautomator2` — only if the error suggests a device connectivity or prerequisite problem.
+   - XCUITest: `xcodebuild -version` and `appium driver doctor xcuitest` — only if the error suggests a build, signing, or toolchain problem.
+   If any doctor or prerequisite check fails, switch to the matching setup skill before deeper troubleshooting. Use `references/community-search.md` only after the relevant official reference does not explain the exact stack trace or symptom.
 
 3. **Open only the references that match the selected driver and symptom**
    Do not load both driver branches in one run. Start with the most direct reference for the observed symptom and only expand if that file does not explain the behavior.

--- a/skills/appium-troubleshooting/SKILL.md
+++ b/skills/appium-troubleshooting/SKILL.md
@@ -1,52 +1,55 @@
 ---
 name: "appium-troubleshooting"
-description: "Diagnose common Appium UiAutomator2 and XCUITest failures, including session startup, driver readiness, WebDriverAgent issues, and element lookup or locator problems"
+description: "Diagnose common Appium failures with a driver-scoped flow for UiAutomator2 or XCUITest, covering startup, driver readiness, WebDriverAgent, and element lookup issues"
 metadata:
-  last_modified: "Sat, 14 Mar 2026 17:21:12 GMT"
+  last_modified: "Tue, 17 Mar 2026 11:40:00 GMT"
 
 ---
 # appium-troubleshooting
 
 ## Goal
-Help the agent narrow Appium failures into a small set of common buckets, apply the smallest plausible fix, and re-run the failing check until the root cause is confirmed or clearly handed back to the user.
+Help the agent narrow a single-driver Appium failure into a small set of common buckets, apply the smallest plausible fix, and re-run the failing check until the root cause is confirmed or clearly handed back to the user.
 
 ## Decision Logic
-- If the failure is really an environment or driver-install problem (`node`, `npm`, `appium`, Java, Android SDK, Xcode, doctor failures): run the relevant setup skill first.
-- If Android fails before the app settles, the wrong activity is detected, the session drops early, or `socket hang up` appears: read [references/uiautomator2-session-startup.md](references/uiautomator2-session-startup.md).
-- If Android locators are slow, flaky, or incorrect: read [references/uiautomator2-locators.md](references/uiautomator2-locators.md).
-- If iOS fails around WebDriverAgent startup, app install, system alerts, device communication, or simulator state: read [references/xcuitest-troubleshooting.md](references/xcuitest-troubleshooting.md).
-- If iOS elements cannot be found, the tree looks incomplete, or lookup performance is poor: read [references/xcuitest-element-lookup.md](references/xcuitest-element-lookup.md) and [references/xcuitest-locators.md](references/xcuitest-locators.md).
-- If the official docs do not explain the exact stack trace or symptom, use [references/community-search.md](references/community-search.md) as a fallback search workflow.
+- Identify the active automation driver first (`uiautomator2` or `xcuitest`). If unknown, stop and ask for the failing session capabilities/log line that names the driver.
+- If the failure is an environment or driver-install problem (`node`, `npm`, `appium`, Java, Android SDK, `Xcode`, doctor failures): run the matching setup skill for the selected driver first.
+- UiAutomator2 path only:
+  - session startup, wrong activity, early drop, or `socket hang up`: read [references/uiautomator2-session-startup.md](references/uiautomator2-session-startup.md).
+  - locator issues: read [references/uiautomator2-locators.md](references/uiautomator2-locators.md).
+- XCUITest path only:
+  - WebDriverAgent startup/install/reachability, app install/launch, device/simulator state: read [references/xcuitest-troubleshooting.md](references/xcuitest-troubleshooting.md).
+  - element lookup or locator issues: read [references/xcuitest-element-lookup.md](references/xcuitest-element-lookup.md) and [references/xcuitest-locators.md](references/xcuitest-locators.md).
+- If the official docs do not explain the exact stack trace or symptom, use [references/community-search.md](references/community-search.md) as a fallback workflow.
 
 ## Instructions
-1. **Capture the exact failing surface first**
-   Record the failing command, the exact error text, the platform, the automation driver, and the capabilities in play.
+1. **Capture the exact failing surface and driver scope first**
+   Record the failing command, exact error text, platform, automation driver, and capabilities in play.
    Minimum commands:
    ```bash
    appium -v
    appium driver list --installed
    ```
-   Android:
+   UiAutomator2-only checks:
    ```bash
    adb devices -l
    appium driver doctor uiautomator2
    ```
-   iOS:
+   XCUITest-only checks:
    ```bash
    xcodebuild -version
    appium driver doctor xcuitest
    ```
 
-2. **Classify the failure before changing anything**
-   Choose one primary bucket:
+2. **Classify the failure in the selected driver path before changing anything**
+   Choose one primary bucket for that driver:
    - prerequisite or doctor failure
    - session startup or app launch failure
    - device or simulator connectivity/state issue
    - element lookup or locator issue
    - unknown, but reproducible from logs
 
-3. **Open only the relevant reference file**
-   Do not load every reference file by default. Start with the bucket that best matches the symptom, then expand only if the first path does not explain the behavior.
+3. **Open only driver-specific references**
+   Do not load both driver branches in one run. Start with the matching bucket in the selected driver path and expand only if the first file does not explain the behavior.
 
 4. **Apply one targeted fix at a time**
    Prefer capability corrections, driver cleanup, device reset, or locator changes before broader environment churn.
@@ -56,10 +59,22 @@ Help the agent narrow Appium failures into a small set of common buckets, apply 
    - the single failing locator or inspector lookup for element issues
 
 5. **Use official docs first, community second**
-   The references in this skill summarize the official UiAutomator2 and XCUITest docs collected for `https://github.com/appium/skills/issues/9`.
-   Use `discuss.appium.io` only after the official references are exhausted, and search by exact error text plus driver name and platform version.
+   Official references for this skill:
+   - `https://appium.io/docs/en/latest/`
+   - `https://github.com/appium/appium-uiautomator2-driver`
+   - `https://appium.github.io/appium-xcuitest-driver/latest/`
+   - `https://github.com/appium/appium-xcuitest-driver`
+   Use `discuss.appium.io` only after the official references are exhausted, searching with exact error text plus driver name and platform version.
 
-6. **Keep the result evidence-based**
+6. **Record checks/tests performed in the troubleshooting result**
+   Include command evidence for:
+   - `appium -v`
+   - `appium driver list --installed`
+   - selected-driver doctor output (`appium driver doctor uiautomator2` or `appium driver doctor xcuitest`)
+   - one minimal failing reproduction re-run after the fix
+   - platform check tied to selected driver (`adb devices -l` for UiAutomator2, `xcodebuild -version` for XCUITest)
+
+7. **Keep the result evidence-based**
    End with:
    - the confirmed or most likely root cause
    - the change that was made
@@ -75,4 +90,5 @@ Mark troubleshooting complete only when one of these is true:
 - Treat Appium doctor required fixes as blocking.
 - Use global `appium` command mode by default unless the user explicitly asks for local `npx appium`.
 - Prefer the official Appium driver docs referenced by this skill before using community answers.
+- Keep troubleshooting scoped to one driver path (`uiautomator2` or `xcuitest`) per run unless the user explicitly asks for cross-driver comparison.
 - Do not claim success from a theory alone; always tie the conclusion to a reproduced symptom or a passing re-check.

--- a/skills/appium-troubleshooting/references/community-search.md
+++ b/skills/appium-troubleshooting/references/community-search.md
@@ -1,0 +1,27 @@
+# Community Search Fallback
+
+## Source
+- `https://discuss.appium.io/`
+
+## When To Use This
+Use community search only after the official references in this skill do not explain the exact symptom.
+
+## Search Pattern
+- Search the exact error string in quotes.
+- Add the driver name: `uiautomator2` or `xcuitest`.
+- Add the platform version and whether the target is a real device or simulator/emulator.
+- Add the capability name if the issue appears right after changing one capability.
+
+Example queries:
+- `"socket hang up" uiautomator2 Android 14 emulator`
+- `"Activity never started" appWaitActivity uiautomator2`
+- `"WebDriverAgent" xcuitest iOS 18 real device`
+- `"No matches found for Identity Binding" xcuitest`
+
+## How To Filter Results
+- Prefer threads that mention the same Appium major version and the same driver.
+- Prefer posts that include logs or cite official Appium docs.
+- Treat advice that suggests broad resets or unrelated capability changes as low confidence until you can verify it locally.
+
+## Validation Rule
+Never close the issue from a forum answer alone. Reproduce the proposed fix locally and tie it back to the original failing command or locator.

--- a/skills/appium-troubleshooting/references/community-search.md
+++ b/skills/appium-troubleshooting/references/community-search.md
@@ -3,8 +3,14 @@
 ## Source
 - `https://discuss.appium.io/`
 
-## When To Use This
-Use community search only after the official references in this skill do not explain the exact symptom.
+## Official-First Rule
+Use community search only after checking the matching official Appium reference first:
+
+- UiAutomator2 startup: `https://github.com/appium/appium-uiautomator2-driver/blob/master/docs/activity-startup.md`
+- UiAutomator2 locators: `https://github.com/appium/appium-uiautomator2-driver?tab=readme-ov-file#element-location`
+- XCUITest element lookup: `https://appium.github.io/appium-xcuitest-driver/latest/guides/elements-lookup-troubleshooting/`
+- XCUITest locators: `https://appium.github.io/appium-xcuitest-driver/latest/reference/locator-strategies/`
+- XCUITest general failures: `https://appium.github.io/appium-xcuitest-driver/latest/guides/troubleshooting/`
 
 ## Search Pattern
 - Search the exact error string in quotes.
@@ -18,21 +24,17 @@ Example queries:
 - `"WebDriverAgent" xcuitest iOS 18 real device`
 - `"No matches found for Identity Binding" xcuitest`
 
-## Common Case Playbooks
-Use one of these query templates first, then run the paired local check before applying any forum suggestion.
+## Offline Triage Before Searching
+Use one of these cases first. The goal is to do one focused local check before opening forum threads.
 
 | Case | Query Template | First Local Check |
 |---|---|---|
 | UiAutomator2 session drops early | `"socket hang up" uiautomator2 <android-version> <device-type>` | `adb logcat -d` and one clean session retry |
 | UiAutomator2 wrong startup screen | `"Activity never started" appWaitActivity uiautomator2` | verify current activity via `adb shell dumpsys activity activities` |
-| UiAutomator2 server package mismatch | `"io.appium.uiautomator2.server" "instrumentation" failed` | reinstall helper packages and retry one launch |
 | UiAutomator2 no such element on visible node | `"NoSuchElementException" uiautomator2 <locator-type>` | inspect page source and confirm attribute exposure |
-| UiAutomator2 install/start permission issues | `"SecurityException" uiautomator2 adb` | confirm package install state and app permissions on device |
 | XCUITest WDA build/signing errors | `"WebDriverAgent" "xcodebuild" failed xcuitest` | run `appium driver doctor xcuitest` and verify signing config |
 | XCUITest WDA not reachable | `"Could not proxy command to remote server" xcuitest` | capture fresh Appium logs and confirm WDA endpoint reachability |
-| XCUITest app install/launch failure | `"Failed to launch app" xcuitest` | confirm app binary compatibility with target runtime/device |
 | XCUITest lookup tree incomplete | `"elements not visible in source" xcuitest inspector` | rerun source snapshot and verify accessibility exposure |
-| XCUITest real-device trust/dev mode issues | `"Developer Mode" xcuitest real device` | verify device unlock, trust, and Developer Mode state |
 
 ## How To Filter Results
 - Prefer threads that mention the same Appium major version and the same driver.

--- a/skills/appium-troubleshooting/references/community-search.md
+++ b/skills/appium-troubleshooting/references/community-search.md
@@ -18,10 +18,31 @@ Example queries:
 - `"WebDriverAgent" xcuitest iOS 18 real device`
 - `"No matches found for Identity Binding" xcuitest`
 
+## Common Case Playbooks
+Use one of these query templates first, then run the paired local check before applying any forum suggestion.
+
+| Case | Query Template | First Local Check |
+|---|---|---|
+| UiAutomator2 session drops early | `"socket hang up" uiautomator2 <android-version> <device-type>` | `adb logcat -d` and one clean session retry |
+| UiAutomator2 wrong startup screen | `"Activity never started" appWaitActivity uiautomator2` | verify current activity via `adb shell dumpsys activity activities` |
+| UiAutomator2 server package mismatch | `"io.appium.uiautomator2.server" "instrumentation" failed` | reinstall helper packages and retry one launch |
+| UiAutomator2 no such element on visible node | `"NoSuchElementException" uiautomator2 <locator-type>` | inspect page source and confirm attribute exposure |
+| UiAutomator2 install/start permission issues | `"SecurityException" uiautomator2 adb` | confirm package install state and app permissions on device |
+| XCUITest WDA build/signing errors | `"WebDriverAgent" "xcodebuild" failed xcuitest` | run `appium driver doctor xcuitest` and verify signing config |
+| XCUITest WDA not reachable | `"Could not proxy command to remote server" xcuitest` | capture fresh Appium logs and confirm WDA endpoint reachability |
+| XCUITest app install/launch failure | `"Failed to launch app" xcuitest` | confirm app binary compatibility with target runtime/device |
+| XCUITest lookup tree incomplete | `"elements not visible in source" xcuitest inspector` | rerun source snapshot and verify accessibility exposure |
+| XCUITest real-device trust/dev mode issues | `"Developer Mode" xcuitest real device` | verify device unlock, trust, and Developer Mode state |
+
 ## How To Filter Results
 - Prefer threads that mention the same Appium major version and the same driver.
 - Prefer posts that include logs or cite official Appium docs.
 - Treat advice that suggests broad resets or unrelated capability changes as low confidence until you can verify it locally.
+
+## Accept/Reject Rule For Forum Advice
+- Accept only if the suggestion maps directly to your exact error text, same driver, and similar OS/device version.
+- Reject or defer suggestions that require unrelated global resets before reproducing the same failure once.
+- Always re-run the smallest failing check immediately after applying a proposed fix.
 
 ## Validation Rule
 Never close the issue from a forum answer alone. Reproduce the proposed fix locally and tie it back to the original failing command or locator.

--- a/skills/appium-troubleshooting/references/community-search.md
+++ b/skills/appium-troubleshooting/references/community-search.md
@@ -25,16 +25,17 @@ Example queries:
 - `"No matches found for Identity Binding" xcuitest`
 
 ## Offline Triage Before Searching
-Use one of these cases first. The goal is to do one focused local check before opening forum threads.
 
-| Case | Query Template | First Local Check |
+Use one of these recurring cases to choose a search query and one local verification step. Keep the detailed remediation in the official references whenever possible.
+
+| Case | Search Query Seed | Verify First |
 |---|---|---|
-| UiAutomator2 session drops early | `"socket hang up" uiautomator2 <android-version> <device-type>` | `adb logcat -d` and one clean session retry |
-| UiAutomator2 wrong startup screen | `"Activity never started" appWaitActivity uiautomator2` | verify current activity via `adb shell dumpsys activity activities` |
-| UiAutomator2 no such element on visible node | `"NoSuchElementException" uiautomator2 <locator-type>` | inspect page source and confirm attribute exposure |
-| XCUITest WDA build/signing errors | `"WebDriverAgent" "xcodebuild" failed xcuitest` | run `appium driver doctor xcuitest` and verify signing config |
-| XCUITest WDA not reachable | `"Could not proxy command to remote server" xcuitest` | capture fresh Appium logs and confirm WDA endpoint reachability |
-| XCUITest lookup tree incomplete | `"elements not visible in source" xcuitest inspector` | rerun source snapshot and verify accessibility exposure |
+| UiAutomator2 wrong startup screen or `Activity never started` | `"Activity never started" appWaitActivity uiautomator2` | confirm the focused activity via `adb shell dumpsys activity activities` |
+| UiAutomator2 early session drop or `socket hang up` | `"socket hang up" uiautomator2 <android-version> <device-type>` | capture `adb logcat -d` and retry one clean session |
+| UiAutomator2 WebView or Chromedriver mismatch | `"chromedriver" uiautomator2 webview` | confirm the WebView/browser version on the device before changing Chromedriver settings |
+| XCUITest WDA build or signing failure | `"WebDriverAgent" "xcodebuild" failed xcuitest` | run `appium driver doctor xcuitest` and verify the signing setup |
+| XCUITest WDA timeout or proxy failure | `"Could not proxy command to remote server" xcuitest` | capture fresh Appium logs and confirm WDA reachability |
+| XCUITest source tree incomplete or element missing | `"elements not visible in source" xcuitest inspector` | collect a fresh source snapshot and verify accessibility exposure or active context |
 
 ## How To Filter Results
 - Prefer threads that mention the same Appium major version and the same driver.

--- a/skills/appium-troubleshooting/references/uiautomator2-locators.md
+++ b/skills/appium-troubleshooting/references/uiautomator2-locators.md
@@ -1,0 +1,29 @@
+# UiAutomator2 Locators
+
+## Sources
+- `https://github.com/appium/appium-uiautomator2-driver?tab=readme-ov-file#element-location`
+
+## Recommended Locator Order
+1. `accessibility id`
+2. `id`
+3. `-android uiautomator`
+4. `class name` only when scoped to a smaller parent
+5. `xpath` as the last resort
+
+## Guidance
+- `accessibility id` is usually the most portable and most stable choice when the app exposes meaningful accessibility labels or content descriptions.
+- `id` maps well to Android resource ids and is usually the best native fallback when accessibility metadata is missing.
+- `-android uiautomator` is useful for precise native queries when ids are unavailable, but it should stay readable and narrow.
+- `class name` is weak on its own because many nodes share the same class.
+- `xpath` is the most brittle and usually the slowest option; avoid wide tree scans and absolute paths when possible.
+
+## Troubleshooting A Bad Locator
+- Inspect the current page source or Appium Inspector output before changing code.
+- Verify whether the visible text is actually exposed as text, content description, or resource id.
+- If a hybrid app is involved, confirm the current context before debugging native locators.
+- If lookups are flaky, wait for the UI state that makes the target node exist instead of retrying the same weak selector.
+
+## Validation
+- Re-run the smallest failing lookup.
+- Compare the returned attributes against the actual source dump.
+- If an `xpath` fix works but a stronger native locator is available, prefer the native locator before closing the issue.

--- a/skills/appium-troubleshooting/references/uiautomator2-locators.md
+++ b/skills/appium-troubleshooting/references/uiautomator2-locators.md
@@ -12,6 +12,22 @@ Use the driver docs for the full strategy list and performance tradeoffs. Keep t
 - Treat a working `xpath` as proof that the node exists, not as the preferred final fix. Replace it with a stronger native locator when the source exposes one.
 - If the node is not present in source at all, this is usually an app-state, accessibility, or context problem rather than locator syntax.
 
+## Hybrid App Checks
+- If the element is inside a WebView, confirm the failing lookup is happening in a `WEBVIEW_*` context rather than `NATIVE_APP`.
+- If the failure started after a Chrome or Android System WebView update, confirm the WebView/browser version before changing Chromedriver settings.
+- Use the UiAutomator2 driver's Chromedriver compatibility guidance before community fallback. Prefer `appium:chromedriverExecutable`, `appium:chromedriverExecutableDir`, or automatic Chromedriver discovery over ad hoc workarounds.
+- If the node exists only in the WebView DOM and not in native page source, switch context first and re-run the same single lookup before changing selectors.
+
+## Hybrid App Checks With Commands
+```bash
+adb shell dumpsys package com.android.chrome | grep versionName
+adb shell dumpsys package com.google.android.webview | grep versionName
+adb shell dumpsys package com.android.webview | grep versionName
+```
+- Capture the current context list from the failing client run and confirm the target lookup is using the expected `WEBVIEW_*` context.
+- Capture one source snapshot from `NATIVE_APP` and one from the target `WEBVIEW_*` context on the same screen. If the element appears only in the WebView DOM, switch context before changing selectors.
+- If Chromedriver is the likely mismatch, prefer updating `appium:chromedriverExecutable`, `appium:chromedriverExecutableDir`, or the Chromedriver mapping instead of rewriting the locator first.
+
 ## Validation
 - Re-run the smallest failing lookup.
 - Compare the returned attributes against the actual source dump.

--- a/skills/appium-troubleshooting/references/uiautomator2-locators.md
+++ b/skills/appium-troubleshooting/references/uiautomator2-locators.md
@@ -1,27 +1,16 @@
 # UiAutomator2 Locators
 
-## Sources
+## Official Reference
 - `https://github.com/appium/appium-uiautomator2-driver?tab=readme-ov-file#element-location`
 
-## Recommended Locator Order
-1. `accessibility id`
-2. `id`
-3. `-android uiautomator`
-4. `class name` only when scoped to a smaller parent
-5. `xpath` as the last resort
+Use the driver docs for the full strategy list and performance tradeoffs. Keep this page for the extra triage that is easy to miss during debugging.
 
-## Guidance
-- `accessibility id` is usually the most portable and most stable choice when the app exposes meaningful accessibility labels or content descriptions.
-- `id` maps well to Android resource ids and is usually the best native fallback when accessibility metadata is missing.
-- `-android uiautomator` is useful for precise native queries when ids are unavailable, but it should stay readable and narrow.
-- `class name` is weak on its own because many nodes share the same class.
-- `xpath` is the most brittle and usually the slowest option; avoid wide tree scans and absolute paths when possible.
-
-## Troubleshooting A Bad Locator
-- Inspect the current page source or Appium Inspector output before changing code.
-- Verify whether the visible text is actually exposed as text, content description, or resource id.
-- If a hybrid app is involved, confirm the current context before debugging native locators.
-- If lookups are flaky, wait for the UI state that makes the target node exist instead of retrying the same weak selector.
+## Local Guidance
+- Inspect the current page source before changing the selector. Verify whether the target is exposed as `content-desc`, resource id, text, or only as a visual label.
+- If the app is hybrid, confirm the current context before debugging native locators.
+- `-android uiautomator` is useful when ids or accessibility metadata are missing, but keep the query narrow and readable enough to debug from logs.
+- Treat a working `xpath` as proof that the node exists, not as the preferred final fix. Replace it with a stronger native locator when the source exposes one.
+- If the node is not present in source at all, this is usually an app-state, accessibility, or context problem rather than locator syntax.
 
 ## Validation
 - Re-run the smallest failing lookup.

--- a/skills/appium-troubleshooting/references/uiautomator2-session-startup.md
+++ b/skills/appium-troubleshooting/references/uiautomator2-session-startup.md
@@ -1,6 +1,6 @@
 # UiAutomator2 Session Startup
 
-## Sources
+## Official References
 - `https://github.com/appium/appium-uiautomator2-driver/blob/master/docs/activity-startup.md`
 - `https://github.com/appium/appium-uiautomator2-driver?tab=readme-ov-file#troubleshooting`
 
@@ -11,19 +11,16 @@
 - `socket hang up`
 - the UiAutomator2 server appears to die during startup
 
-## Common Patterns
-- The default launch heuristics picked the wrong Android activity.
-  Fix by setting `appium:appPackage`, `appium:appActivity`, `appium:appWaitPackage`, and `appium:appWaitActivity` to the app's actual startup flow.
-- The app passes through several transient activities before it becomes stable.
-  Use a comma-separated `appWaitActivity` list or a wildcard when the startup path legitimately varies.
-- The app needs longer to settle before Appium should continue.
-  Increase `appium:appWaitDuration` rather than masking the problem with arbitrary test sleeps.
-- The device or helper server is in a bad state.
-  `socket hang up` usually means the UiAutomator2 server or its transport died. Clear stale sessions, restart `adb`, and reinstall the helper packages if needed.
-- The failure is not really about activities.
-  If install, signing, ABI, permission, or instrumentation errors appear in logs, fix that underlying issue first and then retry startup.
+This file is a shortcut into the official driver docs, not a replacement for them.
 
-## Useful Checks
+## Local Triage
+1. Verify the package and foreground activity from the device state, not from the manifest guess.
+2. Align `appium:appPackage`, `appium:appActivity`, `appium:appWaitPackage`, and `appium:appWaitActivity` with the observed startup flow.
+3. If the app legitimately passes through multiple transient activities, list those wait activities explicitly before increasing `appium:appWaitDuration`.
+4. If logs show `socket hang up`, instrumentation failure, or helper-package errors, treat it as a UiAutomator2 helper or `adb` transport problem first.
+5. If logs show install, ABI, permission, or signing failures, stop tuning startup capabilities and fix that underlying failure first.
+
+## Minimal Checks
 ```bash
 adb shell dumpsys window windows
 adb shell dumpsys activity activities
@@ -31,21 +28,14 @@ adb shell pm list packages
 adb logcat -d
 ```
 
-## Practical Fix Order
-1. Confirm the package and activity the app actually reaches on the device.
-2. Align `appPackage`, `appActivity`, `appWaitPackage`, and `appWaitActivity` with that flow.
-3. If the session still dies early, restart the transport:
-   ```bash
-   adb kill-server
-   adb start-server
-   ```
-4. If the helper server looks stale, remove the Appium helper packages and retry:
-   ```bash
-   adb uninstall io.appium.uiautomator2.server
-   adb uninstall io.appium.uiautomator2.server.test
-   ```
-5. Re-run the same single session launch and inspect fresh logs before changing anything else.
+## One Clean Retry
+If startup still dies early after the first log review, do one clean retry:
 
-## Notes
-- Prefer collecting the focused activity from `dumpsys` over guessing from the app manifest alone.
-- If the app's first-launch flow genuinely differs from later launches, capture both paths in the troubleshooting notes.
+```bash
+adb kill-server
+adb start-server
+adb uninstall io.appium.uiautomator2.server
+adb uninstall io.appium.uiautomator2.server.test
+```
+
+Then re-run the same single session launch and compare fresh logs before changing anything else.

--- a/skills/appium-troubleshooting/references/uiautomator2-session-startup.md
+++ b/skills/appium-troubleshooting/references/uiautomator2-session-startup.md
@@ -20,13 +20,25 @@ This file is a shortcut into the official driver docs, not a replacement for the
 4. If logs show `socket hang up`, instrumentation failure, or helper-package errors, treat it as a UiAutomator2 helper or `adb` transport problem first.
 5. If logs show install, ABI, permission, or signing failures, stop tuning startup capabilities and fix that underlying failure first.
 
+## Log Clues To Separate Common Causes
+- Activity mismatch is more likely if `adb shell dumpsys activity activities` shows a different foreground activity than the one implied by `appium:appActivity` or `appium:appWaitActivity`, or if Appium reports `Activity never started`.
+- A UiAutomator2 server crash is more likely if `adb logcat -d` shows instrumentation failure, `io.appium.uiautomator2.server` package errors, or the Appium log says it cannot connect to the UiAutomator2 REST server.
+- An `adb` transport drop is more likely if the device disappears from `adb devices -l`, the Appium log shows proxy/connectivity resets, or multiple commands fail immediately after `adb` communication errors.
+
 ## Minimal Checks
 ```bash
 adb shell dumpsys window windows
 adb shell dumpsys activity activities
 adb shell pm list packages
 adb logcat -d
+grep -i "socket hang up\|uiautomator2\|instrumentation\|adb\|cannot connect" <appium-server-log-file>
 ```
+
+## First Pass Order
+1. Capture `dumpsys activity`, `adb logcat -d`, and the matching Appium server log lines from the failing session.
+2. Decide whether the first failure signal is activity mismatch, UiAutomator2 server crash, or `adb` transport loss.
+3. Apply only the fix for that first signal.
+4. Re-run one fresh session start before changing anything else.
 
 ## One Clean Retry
 If startup still dies early after the first log review, do one clean retry:

--- a/skills/appium-troubleshooting/references/uiautomator2-session-startup.md
+++ b/skills/appium-troubleshooting/references/uiautomator2-session-startup.md
@@ -1,0 +1,51 @@
+# UiAutomator2 Session Startup
+
+## Sources
+- `https://github.com/appium/appium-uiautomator2-driver/blob/master/docs/activity-startup.md`
+- `https://github.com/appium/appium-uiautomator2-driver?tab=readme-ov-file#troubleshooting`
+
+## When To Read This
+- `Activity never started`
+- app launches the wrong screen or splash flow
+- `appWaitActivity` or `appWaitPackage` mismatches
+- `socket hang up`
+- the UiAutomator2 server appears to die during startup
+
+## Common Patterns
+- The default launch heuristics picked the wrong Android activity.
+  Fix by setting `appium:appPackage`, `appium:appActivity`, `appium:appWaitPackage`, and `appium:appWaitActivity` to the app's actual startup flow.
+- The app passes through several transient activities before it becomes stable.
+  Use a comma-separated `appWaitActivity` list or a wildcard when the startup path legitimately varies.
+- The app needs longer to settle before Appium should continue.
+  Increase `appium:appWaitDuration` rather than masking the problem with arbitrary test sleeps.
+- The device or helper server is in a bad state.
+  `socket hang up` usually means the UiAutomator2 server or its transport died. Clear stale sessions, restart `adb`, and reinstall the helper packages if needed.
+- The failure is not really about activities.
+  If install, signing, ABI, permission, or instrumentation errors appear in logs, fix that underlying issue first and then retry startup.
+
+## Useful Checks
+```bash
+adb shell dumpsys window windows
+adb shell dumpsys activity activities
+adb shell pm list packages
+adb logcat -d
+```
+
+## Practical Fix Order
+1. Confirm the package and activity the app actually reaches on the device.
+2. Align `appPackage`, `appActivity`, `appWaitPackage`, and `appWaitActivity` with that flow.
+3. If the session still dies early, restart the transport:
+   ```bash
+   adb kill-server
+   adb start-server
+   ```
+4. If the helper server looks stale, remove the Appium helper packages and retry:
+   ```bash
+   adb uninstall io.appium.uiautomator2.server
+   adb uninstall io.appium.uiautomator2.server.test
+   ```
+5. Re-run the same single session launch and inspect fresh logs before changing anything else.
+
+## Notes
+- Prefer collecting the focused activity from `dumpsys` over guessing from the app manifest alone.
+- If the app's first-launch flow genuinely differs from later launches, capture both paths in the troubleshooting notes.

--- a/skills/appium-troubleshooting/references/xcuitest-element-lookup.md
+++ b/skills/appium-troubleshooting/references/xcuitest-element-lookup.md
@@ -1,0 +1,32 @@
+# XCUITest Element Lookup Troubleshooting
+
+## Sources
+- `https://appium.github.io/appium-xcuitest-driver/latest/guides/elements-lookup-troubleshooting/`
+
+## When To Read This
+- elements visible to a human are missing in Appium Inspector
+- source dumps look incomplete
+- an iOS locator works intermittently
+- lookup is unexpectedly slow
+
+## Common Patterns
+- The app does not expose useful accessibility metadata.
+  If the element is missing from the accessibility tree, Appium cannot reliably find it. Confirm with page source before rewriting selectors.
+- The wrong app or window is active.
+  Verify Appium is attached to the expected foreground app before assuming the locator is wrong.
+- The snapshot is incomplete or too expensive.
+  Deep or complex trees can produce incomplete or slow snapshots. Adjust snapshot-related settings only after confirming the tree depth is the real issue.
+- The UI has not settled yet.
+  Visibility and hittability can lag during transitions. Wait for the state that makes the element queryable instead of retrying a stale screen.
+- A hybrid context mismatch is hiding the element.
+  If the app uses web content, confirm the active context before continuing native element debugging.
+
+## Debugging Order
+1. Confirm the element exists in the current source dump.
+2. Inspect which attributes the element actually exposes (`name`, `label`, `value`, type, visibility).
+3. Verify the active app, window, and context.
+4. Only then adjust snapshot depth or lookup-related settings.
+
+## Notes
+- A missing element in source is usually an accessibility or app-state problem first, not a selector syntax problem.
+- When you change a lookup-related setting, re-run the same single query and compare the new source output rather than changing multiple knobs at once.

--- a/skills/appium-troubleshooting/references/xcuitest-element-lookup.md
+++ b/skills/appium-troubleshooting/references/xcuitest-element-lookup.md
@@ -1,6 +1,6 @@
 # XCUITest Element Lookup Troubleshooting
 
-## Sources
+## Official Reference
 - `https://appium.github.io/appium-xcuitest-driver/latest/guides/elements-lookup-troubleshooting/`
 
 ## When To Read This
@@ -9,24 +9,15 @@
 - an iOS locator works intermittently
 - lookup is unexpectedly slow
 
-## Common Patterns
-- The app does not expose useful accessibility metadata.
-  If the element is missing from the accessibility tree, Appium cannot reliably find it. Confirm with page source before rewriting selectors.
-- The wrong app or window is active.
-  Verify Appium is attached to the expected foreground app before assuming the locator is wrong.
-- The snapshot is incomplete or too expensive.
-  Deep or complex trees can produce incomplete or slow snapshots. Adjust snapshot-related settings only after confirming the tree depth is the real issue.
-- The UI has not settled yet.
-  Visibility and hittability can lag during transitions. Wait for the state that makes the element queryable instead of retrying a stale screen.
-- A hybrid context mismatch is hiding the element.
-  If the app uses web content, confirm the active context before continuing native element debugging.
+Use the official guide for the full symptom matrix. This page keeps only the local checks that are easiest to miss.
 
-## Debugging Order
-1. Confirm the element exists in the current source dump.
-2. Inspect which attributes the element actually exposes (`name`, `label`, `value`, type, visibility).
-3. Verify the active app, window, and context.
-4. Only then adjust snapshot depth or lookup-related settings.
+## Local Triage
+1. Collect source from the same environment as the failing test: same simulator or device, OS version, app build, orientation, and permission state.
+2. Confirm the element exists in the current source dump before changing selector syntax.
+3. Inspect the attributes the element actually exposes: `name`, `label`, `value`, type, visibility, and enabled state.
+4. Verify the active application and window in WebDriverAgent. System alerts, share sheets, and other overlays may belong to a different active app.
+5. Change snapshot-related settings only after confirming a deep or incomplete tree problem, then compare the same single lookup before and after.
 
 ## Notes
-- A missing element in source is usually an accessibility or app-state problem first, not a selector syntax problem.
-- When you change a lookup-related setting, re-run the same single query and compare the new source output rather than changing multiple knobs at once.
+- A missing element in source is usually an accessibility, app-state, or active-application problem first, not a locator problem.
+- If the app uses web content, confirm the current context before continuing native lookup debugging.

--- a/skills/appium-troubleshooting/references/xcuitest-locators.md
+++ b/skills/appium-troubleshooting/references/xcuitest-locators.md
@@ -1,0 +1,27 @@
+# XCUITest Locators
+
+## Sources
+- `https://appium.github.io/appium-xcuitest-driver/latest/reference/locator-strategies/`
+
+## Recommended Locator Order
+1. `accessibility id`
+2. `id` or `name` only when the source proves they are stable in this app
+3. `-ios predicate string`
+4. `-ios class chain`
+5. `xpath` as the last resort
+
+## Guidance
+- `accessibility id` is usually the strongest default for native iOS UI because it aligns with accessibility metadata and avoids tree-wide scans.
+- `id` and `name` may overlap in iOS source output, but do not assume that without checking the actual attributes exposed by the app.
+- `-ios predicate string` is usually the best expressive native fallback when you need attribute filtering.
+- `-ios class chain` is efficient for scoped hierarchy queries when you already know the container path.
+- `xpath` is usually slower and more fragile than native strategies, especially on large hierarchies.
+
+## Troubleshooting A Bad Locator
+- Verify the target attributes in the current source dump before changing the selector.
+- If the element exists but performance is poor, move from `xpath` to a native locator whenever possible.
+- If the element does not exist in source, switch to the element-lookup troubleshooting workflow rather than iterating locator syntax.
+
+## Validation
+- Re-run the exact failing lookup against the same screen.
+- Prefer the simplest native selector that still uniquely identifies the element.

--- a/skills/appium-troubleshooting/references/xcuitest-locators.md
+++ b/skills/appium-troubleshooting/references/xcuitest-locators.md
@@ -1,26 +1,15 @@
 # XCUITest Locators
 
-## Sources
+## Official Reference
 - `https://appium.github.io/appium-xcuitest-driver/latest/reference/locator-strategies/`
 
-## Recommended Locator Order
-1. `accessibility id`
-2. `id` or `name` only when the source proves they are stable in this app
-3. `-ios predicate string`
-4. `-ios class chain`
-5. `xpath` as the last resort
+Use the driver docs for the full strategy ordering and syntax. This page keeps only the local debugging notes that help choose among them.
 
-## Guidance
-- `accessibility id` is usually the strongest default for native iOS UI because it aligns with accessibility metadata and avoids tree-wide scans.
-- `id` and `name` may overlap in iOS source output, but do not assume that without checking the actual attributes exposed by the app.
-- `-ios predicate string` is usually the best expressive native fallback when you need attribute filtering.
-- `-ios class chain` is efficient for scoped hierarchy queries when you already know the container path.
-- `xpath` is usually slower and more fragile than native strategies, especially on large hierarchies.
-
-## Troubleshooting A Bad Locator
-- Verify the target attributes in the current source dump before changing the selector.
-- If the element exists but performance is poor, move from `xpath` to a native locator whenever possible.
-- If the element does not exist in source, switch to the element-lookup troubleshooting workflow rather than iterating locator syntax.
+## Local Guidance
+- On XCUITest, `id`, `name`, and `accessibility id` are treated as synonyms over the element `name` attribute. Check the current source before assuming that attribute is stable in this app.
+- Use `-ios predicate string` or `-ios class chain` when you need native filtering or hierarchy scoping; keep the query tied to attributes that are visible in source.
+- Treat `xpath` as a fallback for cases where the source does not expose a simpler native path. If `xpath` is the first thing that works, use it to learn the tree and then replace it if a native selector is available.
+- If the element is absent from source, stop iterating locator syntax and switch to the element-lookup troubleshooting flow.
 
 ## Validation
 - Re-run the exact failing lookup against the same screen.

--- a/skills/appium-troubleshooting/references/xcuitest-troubleshooting.md
+++ b/skills/appium-troubleshooting/references/xcuitest-troubleshooting.md
@@ -2,6 +2,7 @@
 
 ## Sources
 - `https://appium.github.io/appium-xcuitest-driver/latest/guides/troubleshooting/`
+- `https://github.com/appium/appium-xcuitest-driver`
 
 ## When To Read This
 - WebDriverAgent does not build, install, or stay reachable
@@ -13,8 +14,8 @@
 ## Common Patterns
 - WebDriverAgent setup is broken.
   Re-check Xcode selection, signing requirements for real devices, and driver doctor output before touching the test code.
-- The device is reachable, but the XCTest channel is unstable.
-  Real-device issues often need trust, unlock, Developer Mode, or a device restart before Appium changes will matter.
+- The Appium <-> WebDriverAgent HTTP transport is unstable.
+  This usually appears as proxy timeouts, connection resets, or commands that fail right after session start. Verify WDA logs and real-device trust/unlock/Developer Mode state before changing test code.
 - System alerts are blocking the app under test.
   Use `appium:autoAcceptAlerts` or `appium:autoDismissAlerts` only when that matches the test intent; otherwise handle the alert explicitly.
 - The simulator is in a bad state.
@@ -29,6 +30,7 @@ xcode-select -p
 appium driver doctor xcuitest
 xcrun simctl list devices
 xcrun simctl list runtimes
+grep -i "WebDriverAgent\|Proxying\|timed out" <appium-server-log-file>
 ```
 
 ## Practical Fix Order

--- a/skills/appium-troubleshooting/references/xcuitest-troubleshooting.md
+++ b/skills/appium-troubleshooting/references/xcuitest-troubleshooting.md
@@ -1,6 +1,6 @@
 # XCUITest Troubleshooting
 
-## Sources
+## Official References
 - `https://appium.github.io/appium-xcuitest-driver/latest/guides/troubleshooting/`
 - `https://github.com/appium/appium-xcuitest-driver`
 
@@ -11,17 +11,16 @@
 - system alerts block automation
 - simulator or real-device state looks corrupted
 
-## Common Patterns
-- WebDriverAgent setup is broken.
-  Re-check Xcode selection, signing requirements for real devices, and driver doctor output before touching the test code.
-- The Appium <-> WebDriverAgent HTTP transport is unstable.
-  This usually appears as proxy timeouts, connection resets, or commands that fail right after session start. Verify WDA logs and real-device trust/unlock/Developer Mode state before changing test code.
-- System alerts are blocking the app under test.
-  Use `appium:autoAcceptAlerts` or `appium:autoDismissAlerts` only when that matches the test intent; otherwise handle the alert explicitly.
-- The simulator is in a bad state.
-  Shut down or reset the simulator only when the app data is disposable and the failure clearly points to simulator corruption.
-- App installation behavior is the real failure.
-  Confirm the app build is valid for the target device/runtime before treating it as a generic Appium problem.
+This page is a compact entry point into the official XCUITest troubleshooting guide.
+
+## Local Triage Map
+| Symptom | Verify First | Avoid Until Confirmed |
+|---|---|---|
+| WDA build or signing failure | `xcode-select`, `xcodebuild -version`, `appium driver doctor xcuitest`, and real-device signing setup | changing unrelated test capabilities |
+| Proxy timeout or connection reset right after session start | fresh Appium logs, WDA reachability, and real-device unlock/trust/Developer Mode state | blaming locators or app logic |
+| App install or launch fails | app binary compatibility with the target runtime or device | treating it as a generic WDA failure |
+| System alert blocks the test | whether the alert should be explicitly handled or automatically accepted/dismissed | enabling auto-alert handling without matching test intent |
+| One simulator behaves differently from others | one clean shutdown and retry | erase/reset before confirming corruption |
 
 ## Useful Checks
 ```bash
@@ -32,13 +31,6 @@ xcrun simctl list devices
 xcrun simctl list runtimes
 grep -i "WebDriverAgent\|Proxying\|timed out" <appium-server-log-file>
 ```
-
-## Practical Fix Order
-1. Reproduce the failure with fresh Appium server logs.
-2. Confirm Xcode and `xcuitest` doctor status.
-3. For real devices, verify signing, trust, unlock state, and Developer Mode before deeper debugging.
-4. For simulators, shut down the target simulator and retry once before considering an erase/reset.
-5. If WebDriverAgent is the failing component, focus on WDA logs and build state before modifying app capabilities unrelated to WDA.
 
 ## Notes
 - Do not treat every iOS launch failure as a locator issue; many are WDA or device-state problems.

--- a/skills/appium-troubleshooting/references/xcuitest-troubleshooting.md
+++ b/skills/appium-troubleshooting/references/xcuitest-troubleshooting.md
@@ -1,0 +1,43 @@
+# XCUITest Troubleshooting
+
+## Sources
+- `https://appium.github.io/appium-xcuitest-driver/latest/guides/troubleshooting/`
+
+## When To Read This
+- WebDriverAgent does not build, install, or stay reachable
+- session startup stalls or fails on simulator or real device
+- app install or launch fails on iOS
+- system alerts block automation
+- simulator or real-device state looks corrupted
+
+## Common Patterns
+- WebDriverAgent setup is broken.
+  Re-check Xcode selection, signing requirements for real devices, and driver doctor output before touching the test code.
+- The device is reachable, but the XCTest channel is unstable.
+  Real-device issues often need trust, unlock, Developer Mode, or a device restart before Appium changes will matter.
+- System alerts are blocking the app under test.
+  Use `appium:autoAcceptAlerts` or `appium:autoDismissAlerts` only when that matches the test intent; otherwise handle the alert explicitly.
+- The simulator is in a bad state.
+  Shut down or reset the simulator only when the app data is disposable and the failure clearly points to simulator corruption.
+- App installation behavior is the real failure.
+  Confirm the app build is valid for the target device/runtime before treating it as a generic Appium problem.
+
+## Useful Checks
+```bash
+xcodebuild -version
+xcode-select -p
+appium driver doctor xcuitest
+xcrun simctl list devices
+xcrun simctl list runtimes
+```
+
+## Practical Fix Order
+1. Reproduce the failure with fresh Appium server logs.
+2. Confirm Xcode and `xcuitest` doctor status.
+3. For real devices, verify signing, trust, unlock state, and Developer Mode before deeper debugging.
+4. For simulators, shut down the target simulator and retry once before considering an erase/reset.
+5. If WebDriverAgent is the failing component, focus on WDA logs and build state before modifying app capabilities unrelated to WDA.
+
+## Notes
+- Do not treat every iOS launch failure as a locator issue; many are WDA or device-state problems.
+- If the issue only happens on one device or one simulator runtime, include that environment detail in the root-cause summary.

--- a/skills/appium-troubleshooting/references/xcuitest-troubleshooting.md
+++ b/skills/appium-troubleshooting/references/xcuitest-troubleshooting.md
@@ -32,6 +32,21 @@ xcrun simctl list runtimes
 grep -i "WebDriverAgent\|Proxying\|timed out" <appium-server-log-file>
 ```
 
+## Real Device WDA Reachability
+- If WDA builds but commands time out right after session start on a real device, verify that the Appium log is actually proxying to a reachable WDA URL, typically `http://localhost:8100` when port forwarding is active.
+- If you manage WDA yourself, confirm the `appium:webDriverAgentUrl` value points to the actual reachable WDA endpoint, and supply `appium:wdaRemotePort` when the remote device port differs from the local forwarded port.
+- Prefer this real-device check before simulator-only recovery steps.
+
+## Real Device WDA Reachability Sequence
+1. Capture the Appium server log lines around the first timed out command and confirm which WDA URL Appium is proxying to.
+2. If the environment forwards the device port locally, run:
+   ```bash
+   curl -sf http://localhost:8100/status
+   ```
+   A healthy response means the forwarded WDA endpoint is reachable from the host.
+3. If you set `appium:webDriverAgentUrl`, compare it directly with the reachable endpoint. If the device-side port is not the default `8100`, set `appium:wdaRemotePort` to the device-side port that WDA actually listens on.
+4. Only after the reachability check passes should you move on to deeper app or locator troubleshooting.
+
 ## Notes
 - Do not treat every iOS launch failure as a locator issue; many are WDA or device-state problems.
-- If the issue only happens on one device or one simulator runtime, include that environment detail in the root-cause summary.
+- If the issue only happens on one real device or one simulator runtime, include that environment detail in the root-cause summary.


### PR DESCRIPTION
## Summary
- refine `appium-troubleshooting` to stay in one driver path and start from the failing symptom instead of a broader classification flow
- trim the troubleshooting references into compact entry points that defer to official Appium docs first and keep a short community-search fallback for recurring cases
- update `README.md` and `AGENTS.md` so the troubleshooting workflow stays aligned with the driver-scoped behavior

## Checks
- `git diff --check`
- manual scenario validation against the updated troubleshooting skill for:
  - UiAutomator2 `socket hang up` on Android 14 emulator
  - unknown-driver session creation failure
  - XCUITest real-device WebDriverAgent timeouts right after session start

All three scenario checks stayed in the correct driver path and reached a concrete next step without cross-driver drift.

Closing https://github.com/appium/skills/issues/9
